### PR TITLE
Run rustfmt

### DIFF
--- a/src/core/interval.rs
+++ b/src/core/interval.rs
@@ -1,6 +1,6 @@
 //! A module for working with intervals.
 
-use std::fmt::{Display, Formatter, Error};
+use std::fmt::{Display, Error, Formatter};
 
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;

--- a/src/core/note.rs
+++ b/src/core/note.rs
@@ -403,6 +403,7 @@ impl Sub for Note {
 impl Add<Interval> for Note {
     type Output = Self;
 
+    #[rustfmt::skip]
     fn add(self, rhs: Interval) -> Self::Output {
         let new_pitch = self.named_pitch() + rhs.enharmonic_distance();
 
@@ -443,6 +444,7 @@ impl Add<Interval> for Note {
 impl Sub<Interval> for Note {
     type Output = Self;
 
+    #[rustfmt::skip]
     fn sub(self, rhs: Interval) -> Self::Output {
         let new_pitch = self.named_pitch() - rhs.enharmonic_distance();
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -10,7 +10,7 @@ use js_sys::{Array, Object, Reflect};
 use wasm_bindgen::{convert::RefFromWasmAbi, prelude::*};
 
 use crate::core::{
-    base::{HasDescription, HasName, HasPreciseName, HasStaticName, Parsable, Res, PlaybackHandle},
+    base::{HasDescription, HasName, HasPreciseName, HasStaticName, Parsable, PlaybackHandle, Res},
     chord::{Chord, Chordable, HasChord, HasExtensions, HasInversion, HasIsCrunchy, HasModifiers, HasRoot, HasScale, HasSlash},
     interval::Interval,
     named_pitch::HasNamedPitch,
@@ -334,8 +334,8 @@ impl KordChord {
     #[wasm_bindgen]
     #[cfg(feature = "audio")]
     pub async fn play(&self, delay: f32, length: f32, fade_in: f32) -> JsRes<()> {
-        use gloo_timers::future::TimeoutFuture;
         use crate::core::base::Playable;
+        use gloo_timers::future::TimeoutFuture;
 
         let _handle = self.inner.play(delay, length, fade_in).context("Could not start the playback.").to_js_error()?;
 
@@ -354,7 +354,7 @@ impl KordChord {
 // Playback handle.
 
 /// A handle to a [`Chord`] playback.
-/// 
+///
 /// Should be dropped to stop the playback, or after playback is finished.
 #[wasm_bindgen]
 pub struct KordPlaybackHandle {


### PR DESCRIPTION
I ran rustfmt to make it easier for people with format-on-save to contribute (less noisy diff). I added #[rustfmt::skip] in two places to not mess up the manual formatting that is in place already. Let me know what you think.