### PR TITLE
Make `main` optional when compiling to WASM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,6 @@ ml_gpu = ["ml_train", "burn-tch"]
 
 wasm = ["rodio/wasm-bindgen", "wasm-bindgen", "wasm-bindgen-futures", "js-sys", "console_error_panic_hook", "wee_alloc", "gloo-timers"]
 
-wasm_no_main = []
-
 plot = ["plotters"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ ml_gpu = ["ml_train", "burn-tch"]
 
 wasm = ["rodio/wasm-bindgen", "wasm-bindgen", "wasm-bindgen-futures", "js-sys", "console_error_panic_hook", "wee_alloc", "gloo-timers"]
 
+wasm_no_main = []
+
 plot = ["plotters"]
 
 [dependencies]

--- a/src/core/note.rs
+++ b/src/core/note.rs
@@ -418,7 +418,7 @@ impl Add<Interval> for Note {
         // Basically, if we were already "on" the weird one (this is a perfect unision, or perfect octave, etc.), then we don't
         // do anything special.  Otherwise, if we landed on on of these edge cases, then we need to adjust the octave.
         let mut special_octave = 0;
-        
+
         if self.named_pitch != new_pitch {
             if new_pitch == NamedPitch::CFlat
                 || new_pitch == NamedPitch::CDoubleFlat
@@ -459,7 +459,7 @@ impl Sub<Interval> for Note {
         // Basically, if we were already "on" the weird one (this is a perfect unision, or perfect octave, etc.), then we don't
         // do anything special.  Otherwise, if we landed on on of these edge cases, then we need to adjust the octave.
         let mut special_octave = 0;
-        
+
         if self.named_pitch != new_pitch {
             if new_pitch == NamedPitch::CFlat
                 || new_pitch == NamedPitch::CDoubleFlat

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -26,21 +26,6 @@ static ALLOC: wee_alloc::WeeAlloc<'_> = wee_alloc::WeeAlloc::INIT;
 /// The [`Result`] type for the WASM bindings.
 pub type JsRes<T> = Result<T, JsValue>;
 
-// Entrypoint setup.
-
-/// The main entrypoint which sets up global state.
-#[cfg(not(feature = "wasm_no_main"))]
-#[wasm_bindgen(start)]
-pub fn main() {
-    set_panic_hook();
-}
-
-/// Sets the panic hook to print to the console.
-#[wasm_bindgen]
-pub fn set_panic_hook() {
-    panic::set_hook(Box::new(console_error_panic_hook::hook));
-}
-
 // [`Note`] ABI.
 
 /// The [`Note`] wrapper.

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -4,8 +4,6 @@
 
 use std::panic;
 
-use anyhow::Context;
-
 use js_sys::{Array, Object, Reflect};
 use wasm_bindgen::{convert::RefFromWasmAbi, prelude::*};
 
@@ -31,8 +29,15 @@ pub type JsRes<T> = Result<T, JsValue>;
 // Entrypoint setup.
 
 /// The main entrypoint which sets up global state.
+#[cfg(not(feature = "wasm_no_main"))]
 #[wasm_bindgen(start)]
 pub fn main() {
+    set_panic_hook();
+}
+
+/// Sets the panic hook to print to the console.
+#[wasm_bindgen]
+pub fn set_panic_hook() {
     panic::set_hook(Box::new(console_error_panic_hook::hook));
 }
 
@@ -335,6 +340,7 @@ impl KordChord {
     #[cfg(feature = "audio")]
     pub async fn play(&self, delay: f32, length: f32, fade_in: f32) -> JsRes<()> {
         use crate::core::base::Playable;
+        use anyhow::Context;
         use gloo_timers::future::TimeoutFuture;
 
         let _handle = self.inner.play(delay, length, fade_in).context("Could not start the playback.").to_js_error()?;


### PR DESCRIPTION
Not sure this is idiomatic. However, I noticed, that when compiling to e.g. a yew app, which has a `main`, it conflicts with the existing `main` from `kord`. The double negation of `not("wasm_no_main")` is because I didn't want to make this a breaking change, which I guess a feature `"wasm_main"` would have been. Let me know if you prefer a feature `"wasm_main"` as part of the `default-features` perhaps, or something else entirely.