### PR TITLE
Use `std::time::Duration in` `Playable` trait

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -607,7 +607,7 @@ fn play(chord: &Chord, delay: f32, length: f32, fade_in: f32) -> Void {
         use klib::core::base::Playable;
         use std::time::Duration;
 
-        let _playable = chord.play(delay, length, fade_in)?;
+        let _playable = chord.play(Duration::from_secs_f32(delay), Duration::from_secs_f32(length), Duration::from_secs_f32(fade_in))?;
         std::thread::sleep(Duration::from_secs_f32(length));
     }
 

--- a/src/core/base.rs
+++ b/src/core/base.rs
@@ -2,6 +2,8 @@
 
 // Helpers.
 
+use std::time::Duration;
+
 use rodio::{OutputStream, OutputStreamHandle, Sink};
 
 /// Global result type.
@@ -69,5 +71,5 @@ impl PlaybackHandle {
 pub trait Playable {
     /// Plays the [`Playable`].
     #[must_use = "Dropping the PlayableResult will stop the playback."]
-    fn play(&self, delay: f32, length: f32, fade_in: f32) -> Res<PlaybackHandle>;
+    fn play(&self, delay: Duration, length: Duration, fade_in: Duration) -> Res<PlaybackHandle>;
 }


### PR DESCRIPTION
As noted in #10, here are patches to change the signature of `Playable::play` to use `std::time::Duration` instead of `f32`.