### PR TITLE
Set `format_code_in_doc_comments = true`

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,3 +2,4 @@ max_width = 200
 struct_lit_width = 40
 reorder_impl_items = true
 format_macro_bodies = false
+format_code_in_doc_comments = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,31 +3,39 @@
 //! # Examples
 //!
 //! ```
+//! use klib::core::chord::*;
 //! use klib::core::known_chord::KnownChord;
 //! use klib::core::modifier::Degree;
 //! use klib::core::note::*;
-//! use klib::core::chord::*;
 //!
 //! // Check to see what _kind_ of chord this is.
-//! assert_eq!(Chord::new(C).augmented().seven().known_chord(), KnownChord::AugmentedDominant(Degree::Seven));
-//!
+//! assert_eq!(
+//!     Chord::new(C).augmented().seven().known_chord(),
+//!     KnownChord::AugmentedDominant(Degree::Seven)
+//! );
 //! ```
 //!
 //! ```
 //! use klib::core::base::Parsable;
-//! use klib::core::note::*;
 //! use klib::core::chord::*;
+//! use klib::core::note::*;
 //!
 //! // Parse a chord from a string, and inspect the scale.
-//! assert_eq!(Chord::parse("Cm7b5").unwrap().scale(), vec![C, D, EFlat, F, GFlat, AFlat, BFlat]);
+//! assert_eq!(
+//!     Chord::parse("Cm7b5").unwrap().scale(),
+//!     vec![C, D, EFlat, F, GFlat, AFlat, BFlat]
+//! );
 //! ```
 //!
 //! ```
-//! use klib::core::note::*;
 //! use klib::core::chord::*;
+//! use klib::core::note::*;
 //!
 //! // From a note, create a chord, and look at the chord tones.
-//! assert_eq!(C.into_chord().augmented().major7().chord(), vec![C, E, GSharp, B]);
+//! assert_eq!(
+//!     C.into_chord().augmented().major7().chord(),
+//!     vec![C, E, GSharp, B]
+//! );
 //! ```
 
 #![warn(rustdoc::broken_intra_doc_links, rust_2018_idioms, clippy::all, missing_docs)]


### PR DESCRIPTION
This reformats some of the existing doctests. Lemme know what you think.